### PR TITLE
Fix: SliderBinder now initializes Min/Max before the Value is initialized.

### DIFF
--- a/Foundation Databinding/Assets/Foundation/Databinding/Components/SliderBinder.cs
+++ b/Foundation Databinding/Assets/Foundation/Databinding/Components/SliderBinder.cs
@@ -20,9 +20,6 @@ namespace Foundation.Databinding.Components
         protected Slider Target;
 
         [HideInInspector]
-        public BindingInfo ValueBinding = new BindingInfo { BindingName = "Value" };
-
-        [HideInInspector]
         public BindingInfo EnabledBinding = new BindingInfo { BindingName = "Enabled" };
 
         [HideInInspector]
@@ -30,6 +27,9 @@ namespace Foundation.Databinding.Components
 
         [HideInInspector]
         public BindingInfo MaxValue = new BindingInfo { BindingName = "MaxValue" };
+
+		[HideInInspector]
+		public BindingInfo ValueBinding = new BindingInfo { BindingName = "Value" };
 
         protected bool IsInit;
 


### PR DESCRIPTION
Before, Value wouldn't be set, since min/max were 0 (default float).
